### PR TITLE
Implemented Diff Collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work/

--- a/haskvc.cabal
+++ b/haskvc.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 446ce7c726b0042943ece4f50b3b960da752a6d57f67b63852618f4a74aa2e8f
+-- hash: 74b9d09a01c5b7e525bf14769ccee4ef60cbf522c73d4a5eca58b22e6ceefcba
 
 name:           haskvc
 version:        0.1.0.0
@@ -32,9 +32,11 @@ library
   build-depends:
       base >=4.7 && <5
     , containers ==0.6.2.1
-    , directory ==1.3.6.0
+    , directory ==1.3.6.1
     , parsec ==3.1.14.0
     , process ==1.6.10.0
+    , split ==0.2.3.4
+    , time ==1.9.3
   default-language: Haskell2010
 
 executable haskvc-exe
@@ -47,10 +49,12 @@ executable haskvc-exe
   build-depends:
       base >=4.7 && <5
     , containers ==0.6.2.1
-    , directory ==1.3.6.0
+    , directory ==1.3.6.1
     , haskvc
     , parsec ==3.1.14.0
     , process ==1.6.10.0
+    , split ==0.2.3.4
+    , time ==1.9.3
   default-language: Haskell2010
 
 test-suite haskvc-test
@@ -64,8 +68,10 @@ test-suite haskvc-test
   build-depends:
       base >=4.7 && <5
     , containers ==0.6.2.1
-    , directory ==1.3.6.0
+    , directory ==1.3.6.1
     , haskvc
     , parsec ==3.1.14.0
     , process ==1.6.10.0
+    , split ==0.2.3.4
+    , time ==1.9.3
   default-language: Haskell2010

--- a/src/Diff.hs
+++ b/src/Diff.hs
@@ -98,5 +98,3 @@ parseChangeBlock = do
 -- Full diff output parser
 pDiff :: Parsec String () Diff
 pDiff = many parseChangeBlock
-    
-

--- a/src/DirectoryTree.hs
+++ b/src/DirectoryTree.hs
@@ -3,7 +3,7 @@ import System.Directory
 import System.Process
 import Data.Tree
 import Data.Time
-import Data.Time.LocalTime
+import Data.Time.Clock
 import Data.List.Split
 import Data.List
 import Data.Monoid
@@ -19,15 +19,6 @@ dirTreeToTree (File s i) = Node ((show i)++ " " ++ s) []
 dirTreeToTree (Directory s []) = Node s []
 dirTreeToTree (Directory s tl) = Node s (map dirTreeToTree tl)
 
--- Turns list containing IO wrapped values into
--- a IO wrapped list of values. 
-unwrapListMonads :: [IO a] -> IO [a]
-unwrapListMonads (m:ms) = do
-    entry <- m
-    remaining <- unwrapListMonads ms
-    return (entry:remaining)
-unwrapListMonads [] = return []
-
 -- Directory tree data structure
 data DirTree
    = Directory
@@ -39,51 +30,54 @@ data DirTree
    , fid :: Int
    } deriving (Show)
 
-lastModified :: FilePath -> IO LocalTime
-lastModified fpath = do 
-    (_,out,_) <- readProcessWithExitCode "stat" [fpath, "-c %y"] ""
+-- We only ever want to compare files 
+-- and directories by name
+instance Eq DirTree where
+    (Directory a _) == (Directory b _) = a == b
+    (File a _) == (File b _) = a == b
+    _ == _ = False
 
-    let (dateString:timeString:_) = words out
-    
-    let timestamp = head $ splitOn "." $ timeString
+type DiffInfo = ([String], [String], [String])
 
-    parsedDate <- parseTimeM True defaultTimeLocale "%Y-%0m-%0d" dateString :: IO Day
+data Commit = Commit { timestamp :: UTCTime, tree :: DirTree } deriving (Show)
 
-    parsedTimeOfDay <- parseTimeM True defaultTimeLocale "%T" timestamp :: IO TimeOfDay
-
-    return $ LocalTime parsedDate parsedTimeOfDay
-
-
--- Compares two directory trees for changes
-compareDirectoryTrees :: LocalTime -> DirTree -> FilePath -> IO ([String], [String], [String])
-compareDirectoryTrees lastCommit commitTree currentRoot = currentTree >>= runComparison commitTree 
+-- Collects DiffInfo ([Additions], [Modifications], [Deletions])
+-- between the current project directory and the previous commit
+collectDiffs :: Commit -> DirTree -> IO DiffInfo
+collectDiffs (Commit lastCommit commitTree) currentTree = runComparison commitTree currentTree
     where
-        currentTree = directoryToTree currentRoot
-
-        reduceUpdateTriples :: [([String], [String], [String])] -> ([String], [String], [String])
-        reduceUpdateTriples triples = foldl (\(a1,b1,c1) (a2,b2,c2) -> (a1++a2,b1++b2,c1++c2)) ([],[],[]) triples
-
         isFile :: DirTree -> Bool
         isFile (File _ _) = True
         isFile _ = False
 
-        runComparison :: DirTree -> DirTree -> IO ([String], [String], [String])
-        runComparison (File name1 id1) (File name2 id2) = do
-            fileModDate <- lastModified name2
+        runComparison :: DirTree -> DirTree -> IO DiffInfo
+        
+        runComparison (File name1 _) (File name2 _) = do
+            fileModDate <- getModificationTime name2
             if name1 == name2 && lastCommit >= fileModDate then
                  return ([], [], [])
             else if name1 == name2 && lastCommit < fileModDate then
                  return ([], [name2], [])
             else return ([name2], [], [name1])
-        runComparison (Directory path1 contents1) (Directory path2 contents2) = do
+
+        runComparison (Directory _ contents1) (Directory _ contents2) = do
             let oldFiles = map name $ filter isFile contents1
             let currentFiles = map name $ filter isFile contents2
 
-            let deletions = [([], [], oldFiles \\ currentFiles)]
-            let creations = [(currentFiles \\ oldFiles, [], [])]
+            let fileDeletions = [([], [], oldFiles \\ currentFiles)]
+            let fileCreations = [(currentFiles \\ oldFiles, [], [])]
+            
+            let contentDeletions = contents1 \\ contents2
+            let contentCreations = contents2 \\ contents1
+            let uncommonContent = contentDeletions ++ contentCreations
 
-            innerComparisons <- sequence $ map (uncurry runComparison) (zip contents1 contents2)
-            return . mconcat $ (creations ++ innerComparisons ++ deletions)
+            let commonContents1 = contents1 \\ uncommonContent
+            let commonContents2 = contents2 \\ uncommonContent
+
+            innerComparisons <- sequence $ map (uncurry runComparison) (zip commonContents1 commonContents2)
+            return . mconcat $ (fileCreations ++ innerComparisons ++ fileDeletions)
+        
+        runComparison _ _ = return ([], [], [])
 
 -- Turns directory into Tree FileID
 directoryToTree :: FilePath -> IO DirTree
@@ -103,7 +97,7 @@ directoryToTree path = entryToTree path
         let entryPaths = map ((path++"/")++) entryNames
 
         let subTreesMonadic = map entryToTree entryPaths
-        subTrees <- unwrapListMonads subTreesMonadic
+        subTrees <- sequence subTreesMonadic
 
         return $ Directory path subTrees
 
@@ -185,6 +179,3 @@ deleteTreeEntry p t = delEntry (pathToList p) t
         helper tar passed (entry:left)
             | name entry == tar         = Just (passed ++ left, entry)
             | otherwise                 = helper tar (entry:passed) left
-
-
-

--- a/src/DirectoryTree.hs
+++ b/src/DirectoryTree.hs
@@ -61,11 +61,11 @@ collectDiffs (Commit lastCommit commitTree) currentTree = runComparison commitTr
             else return ([name2], [], [name1])
 
         runComparison (Directory _ contents1) (Directory _ contents2) = do
-            let oldFiles = map name $ filter isFile contents1
-            let currentFiles = map name $ filter isFile contents2
+            let oldFiles        = map name $ filter isFile contents1
+            let currentFiles    = map name $ filter isFile contents2
 
-            let fileDeletions = [([], [], oldFiles \\ currentFiles)]
-            let fileCreations = [(currentFiles \\ oldFiles, [], [])]
+            let fileDeletions   = [([], [], oldFiles \\ currentFiles)]
+            let fileCreations   = [(currentFiles \\ oldFiles, [], [])]
             
             let contentDeletions = contents1 \\ contents2
             let contentCreations = contents2 \\ contents1
@@ -79,7 +79,7 @@ collectDiffs (Commit lastCommit commitTree) currentTree = runComparison commitTr
         
         runComparison _ _ = return ([], [], [])
 
--- Turns directory into Tree FileID
+-- Turns directory into Tree
 directoryToTree :: FilePath -> IO DirTree
 directoryToTree path = entryToTree path
     where

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,6 +18,34 @@ packages:
       sha256: c17cc12ba9a912521d58d8bcee07830351fe27483d9309ebdac8e32175e10706
   original:
     hackage: parsec-3.1.14.0
+- completed:
+    hackage: time-1.9.3@sha256:8f1b5448722a12a952248b356c9eb366e351226543d9086a2da71270522d5f45,5679
+    pantry-tree:
+      size: 6558
+      sha256: a1043c1719491764f0fa37a1fd70d9451080548a41632fee88d8e1b8db4942d6
+  original:
+    hackage: time-1.9.3
+- completed:
+    hackage: directory-1.3.6.1@sha256:3dc9c69c8e09ec95a7a45c6d06abe0f0d2f604439c37e5f88e5a6c335b088d71,2810
+    pantry-tree:
+      size: 3433
+      sha256: 9247d0e7cfbf9946b922d23bd56a6b765cdb91f71d72f8ae6ed22c94dbd9f1db
+  original:
+    hackage: directory-1.3.6.1
+- completed:
+    hackage: unix-2.7.2.2@sha256:9e93f93cc5a065248120136e83a0a6d1ce93d6eb5ef2a2543f9593e93e164d24,3496
+    pantry-tree:
+      size: 3536
+      sha256: 0b54bf49636d2a8c06e28315710e4437e001e05b4523d6e3cb083ba2426a38b2
+  original:
+    hackage: unix-2.7.2.2
+- completed:
+    hackage: split-0.2.3.4@sha256:bad9bfc9e8e0aca4ac1f7b3a2767ee6b1c199d4a1b6960db5cc3d7674aee5d73,2564
+    pantry-tree:
+      size: 439
+      sha256: d931baa404f6867a23ed342c11ef27613227a7a82ba2324f95da184fffad0bd9
+  original:
+    hackage: split-0.2.3.4
 snapshots:
 - completed:
     size: 532380


### PR DESCRIPTION
`collectDiffs` now compares a Commit to a DirTree representing the project root to check for files added, modified or removed since the last commit. Instead of checking for literal diffs, this is achieved by comparing a file's time last modified (`System.Directory (getModificationTime)`) to the time of the latest commit. 